### PR TITLE
[make] Support windows in makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,8 @@
+ifeq ($(OS),Windows_NT)
+WD=$(shell cygpath --absolute --windows .)
+else
 WD=$(shell pwd)
+endif
 TOP=..
 
 NOT_OCAMLFIND=not-ocamlfind


### PR DESCRIPTION
On windows, the makefile fails because `pwd` returns a unix style path. This changes the makefile to use windows paths if windows is detected. This allows a successful build on windows.