### PR TITLE
Add missing exe suffixes for windows

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,21 +9,23 @@ NOT_OCAMLFIND=not-ocamlfind
 OCAMLFIND=ocamlfind
 PACKAGES=re,fmt,unix,bos
 
-EXE=ya-wrap-ocamlfind fixin join_meta LAUNCH
+EXEC_SUFFIX := $(shell ocamlc -config-var ext_exe)
+
+EXE=ya-wrap-ocamlfind$(EXEC_SUFFIX) fixin$(EXEC_SUFFIX) join_meta$(EXEC_SUFFIX) LAUNCH$(EXEC_SUFFIX)
 
 all: $(EXE)
 	$(MAKE) DESTDIR=$(WD)/$(TOP)/local-install/ install
 
-ya-wrap-ocamlfind: ya_wrap_ocamlfind.ml
+ya-wrap-ocamlfind$(EXEC_SUFFIX): ya_wrap_ocamlfind.ml
 	$(OCAMLFIND) ocamlc -linkpkg -linkall -package $(PACKAGES) $< -o $@
 
-join_meta: join_meta.ml
+join_meta$(EXEC_SUFFIX): join_meta.ml
 	$(OCAMLFIND) ocamlc -linkpkg -linkall -package $(PACKAGES) $< -o $@
 
-fixin: fixin.ml
+fixin$(EXEC_SUFFIX): fixin.ml
 	$(OCAMLFIND) ocamlc -linkpkg -linkall -package $(PACKAGES) $< -o $@
 
-LAUNCH: LAUNCH.ml
+LAUNCH$(EXEC_SUFFIX): LAUNCH.ml
 	$(OCAMLFIND) ocamlc -linkpkg -linkall -package $(PACKAGES) $< -o $@
 
 install::


### PR DESCRIPTION
Omitting these causes an error during the pa_ppx build